### PR TITLE
24-hour time format

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -21,6 +21,7 @@ interface ExtraRenderProps {
 	modifyEvent?: (event: EventApi, oldEvent: EventApi) => Promise<boolean>;
 	eventMouseEnter?: (info: EventHoveringArg) => void;
 	firstDay?: number;
+	timeFormat24h?: boolean;
 }
 
 export function renderCalendar(
@@ -86,6 +87,19 @@ export function renderCalendar(
 			},
 		},
 		firstDay: settings?.firstDay,
+		...(settings?.timeFormat24h &&
+			{
+				eventTimeFormat: {
+					hour: 'numeric',
+					minute: '2-digit',
+					hour12: false
+				},
+				slotLabelFormat: {
+					hour: 'numeric',
+					minute: '2-digit',
+					hour12: false
+				}
+			}),
 		eventSources,
 		eventClick,
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,6 +25,7 @@ export interface FullCalendarSettings {
 	defaultCalendar: number;
 	recursiveLocal: boolean;
 	firstDay: number;
+	timeFormat24h: boolean;
 }
 
 export const DEFAULT_SETTINGS: FullCalendarSettings = {
@@ -32,6 +33,7 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
 	defaultCalendar: 0,
 	recursiveLocal: false,
 	firstDay: 0,
+	timeFormat24h: false
 };
 
 const WEEKDAYS = [
@@ -156,6 +158,17 @@ export class FullCalendarSettingTab extends PluginSettingTab {
 				dropdown.setValue(this.plugin.settings.firstDay.toString());
 				dropdown.onChange(async (codeAsString) => {
 					this.plugin.settings.firstDay = Number(codeAsString);
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName("24-hour format")
+			.setDesc("Display the time in a 24-hour format.")
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.timeFormat24h);
+				toggle.onChange(async (val) => {
+					this.plugin.settings.timeFormat24h = val;
 					await this.plugin.saveSettings();
 				});
 			});

--- a/src/view.ts
+++ b/src/view.ts
@@ -169,6 +169,7 @@ export class CalendarView extends ItemView {
 				}
 			},
 			firstDay: this.plugin.settings.firstDay,
+			timeFormat24h: this.plugin.settings.timeFormat24h,
 		});
 
 		this.plugin.settings.calendarSources


### PR DESCRIPTION
Allows to set the time to the 24-hour format in the plugin settings.
The AM/PM time format style hasn't been modified.

Fixes #33