### PR TITLE
Move toolbar to bottom on mobile

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -7,7 +7,6 @@ import {
 	EventClickArg,
 	EventHoveringArg,
 	EventSourceInput,
-	ToolbarInput,
 } from "@fullcalendar/core";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
@@ -60,24 +59,6 @@ export function renderCalendar(
 			}
 		});
 
-	const toolbar: {
-		headerToolbar?: ToolbarInput;
-		footerToolbar?: ToolbarInput;
-	} = isMobile
-		? {
-				headerToolbar: {
-					left: "prev,next today",
-					center: "title",
-					right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
-				},
-		  }
-		: {
-				footerToolbar: {
-					right: "today,prev,next",
-					left: "timeGrid3Days,timeGridDay,listWeek",
-				},
-		  };
-
 	const cal = new Calendar(containerEl, {
 		plugins: [
 			// View plugins
@@ -97,12 +78,6 @@ export function renderCalendar(
 		nowIndicator: true,
 		scrollTimeReset: false,
 
-		footerToolbar: isMobile
-			? {
-					right: "today,prev,next",
-					left: "timeGrid3Days,timeGridDay,listWeek",
-			  }
-			: false,
 		headerToolbar: !isMobile
 			? {
 					left: "prev,next today",
@@ -110,6 +85,13 @@ export function renderCalendar(
 					right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
 			  }
 			: false,
+		footerToolbar: isMobile
+			? {
+					right: "today,prev,next",
+					left: "timeGrid3Days,timeGridDay,listWeek",
+			  }
+			: false,
+
 		views: {
 			timeGridDay: {
 				type: "timeGrid",
@@ -159,7 +141,6 @@ export function renderCalendar(
 				openContextMenuForEvent && openContextMenuForEvent(event, e);
 			});
 		},
-		// ...toolbar,
 	});
 	cal.render();
 	return cal;

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -7,6 +7,7 @@ import {
 	EventClickArg,
 	EventHoveringArg,
 	EventSourceInput,
+	ToolbarInput,
 } from "@fullcalendar/core";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import timeGridPlugin from "@fullcalendar/timegrid";
@@ -58,6 +59,25 @@ export function renderCalendar(
 				revert();
 			}
 		});
+
+	const toolbar: {
+		headerToolbar?: ToolbarInput;
+		footerToolbar?: ToolbarInput;
+	} = isMobile
+		? {
+				headerToolbar: {
+					left: "prev,next today",
+					center: "title",
+					right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
+				},
+		  }
+		: {
+				footerToolbar: {
+					right: "today,prev,next",
+					left: "timeGrid3Days,timeGridDay,listWeek",
+				},
+		  };
+
 	const cal = new Calendar(containerEl, {
 		plugins: [
 			// View plugins
@@ -77,16 +97,19 @@ export function renderCalendar(
 		nowIndicator: true,
 		scrollTimeReset: false,
 
-		headerToolbar: isMobile
+		footerToolbar: isMobile
 			? {
 					right: "today,prev,next",
 					left: "timeGrid3Days,timeGridDay,listWeek",
 			  }
-			: {
+			: false,
+		headerToolbar: !isMobile
+			? {
 					left: "prev,next today",
 					center: "title",
 					right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
-			  },
+			  }
+			: false,
 		views: {
 			timeGridDay: {
 				type: "timeGrid",
@@ -136,6 +159,7 @@ export function renderCalendar(
 				openContextMenuForEvent && openContextMenuForEvent(event, e);
 			});
 		},
+		// ...toolbar,
 	});
 	cal.render();
 	return cal;

--- a/src/overrides.css
+++ b/src/overrides.css
@@ -1,3 +1,6 @@
+.is-phone .fc {
+	height: calc(100% - 2.25rem);
+}
 .fc {
 	height: 100%;
 	--fc-button-text-color: var(--text-normal);


### PR DESCRIPTION
With Obsidian 1.0, it makes sense to also move the calendar toolbar to the bottom on mobile. Since there's no way to swipe between pages yet (#49), moving the bar to the bottom puts the bar more within reach.

<img width="467" alt="Screen Shot 2022-11-11 at 8 10 38 AM" src="https://user-images.githubusercontent.com/436045/201347315-386e6741-f110-4622-8045-59c191745eb2.png">
