### PR TITLE
Mobile Initial View doesn't save

### DIFF
--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -205,6 +205,7 @@ export class FullCalendarSettingTab extends PluginSettingTab {
                 dropdown.setValue(this.plugin.settings.initialView.mobile);
                 dropdown.onChange(async (initialView) => {
                     this.plugin.settings.initialView.mobile = initialView;
+                    await this.plugin.saveSettings();
                 });
             });
 


### PR DESCRIPTION
Repro Steps:
- open `Settings`
- change `Mobile Initial View` to anything except default `3 Days`
- restart Obsidian

Current:
- `Mobile Initial View` is reset to default `3 Days`

Fixed:
- `Mobile Initial View` is like it was set in Settings