### PR TITLE
Fix path traversal bug when creating events

### DIFF
--- a/src/calendars/FullNoteCalendar.ts
+++ b/src/calendars/FullNoteCalendar.ts
@@ -4,6 +4,7 @@ import { EventPathLocation } from "../core/EventStore";
 import { ObsidianInterface } from "../ObsidianAdapter";
 import { OFCEvent, EventLocation, validateEvent } from "../types";
 import { EditableCalendar, EditableEventResponse } from "./EditableCalendar";
+import { join } from "path";
 
 const basenameFromEvent = (event: OFCEvent): string => {
     switch (event.type) {
@@ -216,7 +217,14 @@ export default class FullNoteCalendar extends EditableCalendar {
     }
 
     async createEvent(event: OFCEvent): Promise<EventLocation> {
-        const path = `${this.directory}/${filenameForEvent(event)}`;
+        const event_filename = filenameForEvent(event);
+        const path = join(this.directory, event_filename);
+
+        if (!path.startsWith(this.directory)) {
+            throw new Error(
+                `Event at ${path} will not be in calendar directory.`
+            );
+        }
         if (this.app.getAbstractFileByPath(path)) {
             throw new Error(`Event at ${path} already exists.`);
         }


### PR DESCRIPTION
Hi!

Very cool extension!

I just would like to point out a tiny bug regarding file paths linked to the `Full Note` calendar mode.

In the `createEvent` function the file path is not checked. As such we can create an event called `/../../event_name` to write a markdown file at an arbitrary location.

The impact is non-existent as only markdown files are created and clearly someone with access to the Obsidian app needs to be adding calendar events ; but well 🙉.

The PR is a fix example.

Have a nice day ☺️