### PR TITLE
Jarekbird/support inline default calendar

### DIFF
--- a/docs/advanced/dataview.md
+++ b/docs/advanced/dataview.md
@@ -13,4 +13,15 @@ calendar.render()
 
 Unfortunately, there's a bug on first render and you need to interact with the calendar by changing the week or view before it renders properly.
 
+`renderCalendar()` includes all events from all event sources set in the global settings when no event sources aer passed in.
+
+````
+```dataviewjs
+this.container.style.minHeight = "500px";
+const { renderCalendar } = app.plugins.plugins["obsidian-full-calendar"];
+let calendar = renderCalendar(this.container);
+calendar.render()
+```
+````
+
 `renderCalendar()` exposes the FullCalendar API directly, so check out [the event parsing documentation](https://fullcalendar.io/docs/event-parsing) to see everything you can do here!

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,9 @@ import {
     FULL_CALENDAR_SIDEBAR_VIEW_TYPE,
     FULL_CALENDAR_VIEW_TYPE,
 } from "./ui/view";
-import { renderCalendar } from "./ui/calendar";
+import { renderCalendar, ExtraRenderProps } from "./ui/calendar";
 import { toEventInput } from "./ui/interop";
+import { translateSources } from "./ui/view"
 import {
     DEFAULT_SETTINGS,
     FullCalendarSettings,
@@ -19,6 +20,7 @@ import FullNoteCalendar from "./calendars/FullNoteCalendar";
 import DailyNoteCalendar from "./calendars/DailyNoteCalendar";
 import ICSCalendar from "./calendars/ICSCalendar";
 import CalDAVCalendar from "./calendars/CalDAVCalendar";
+import { EventSourceInput } from "@fullcalendar/core";
 
 export default class FullCalendarPlugin extends Plugin {
     settings: FullCalendarSettings = DEFAULT_SETTINGS;
@@ -58,7 +60,16 @@ export default class FullCalendarPlugin extends Plugin {
         FOR_TEST_ONLY: () => null,
     });
 
-    renderCalendar = renderCalendar;
+    translateSources = translateSources;
+    renderCalendar = (
+        containerEl: HTMLElement,
+        eventSources: EventSourceInput[],
+        settings?: ExtraRenderProps
+        ) => {
+        if (!eventSources) { eventSources = translateSources(this); }
+        renderCalendar(containerEl, eventSources, settings);
+    };
+
     processFrontmatter = toEventInput;
 
     async activateView() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,12 @@ import {
     FULL_CALENDAR_SIDEBAR_VIEW_TYPE,
     FULL_CALENDAR_VIEW_TYPE,
 } from "./ui/view";
-import { renderCalendar, ExtraRenderProps } from "./ui/calendar";
+import {
+    renderCalendar as calendarRender,
+    ExtraRenderProps,
+} from "./ui/calendar";
 import { toEventInput } from "./ui/interop";
-import { translateSources } from "./ui/view"
+import { translateSources } from "./ui/view";
 import {
     DEFAULT_SETTINGS,
     FullCalendarSettings,
@@ -65,9 +68,11 @@ export default class FullCalendarPlugin extends Plugin {
         containerEl: HTMLElement,
         eventSources: EventSourceInput[],
         settings?: ExtraRenderProps
-        ) => {
-        if (!eventSources) { eventSources = translateSources(this); }
-        renderCalendar(containerEl, eventSources, settings);
+    ) => {
+        if (!eventSources) {
+            eventSources = translateSources(this);
+        }
+        return calendarRender(containerEl, eventSources, settings);
     };
 
     processFrontmatter = toEventInput;

--- a/src/ui/calendar.ts
+++ b/src/ui/calendar.ts
@@ -35,7 +35,7 @@ rrulePlugin.recurringTypes[0].expand = function (errd, fr, de) {
         });
 };
 
-interface ExtraRenderProps {
+export interface ExtraRenderProps {
     eventClick?: (info: EventClickArg) => void;
     select?: (
         startDate: Date,

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -50,13 +50,11 @@ function getCalendarColors(color: string | null | undefined): {
     };
 }
 
-export function translateSources(plugin : FullCalendarPlugin) {
+export function translateSources(plugin: FullCalendarPlugin) {
     return plugin.cache.getAllEvents().map(
         ({ events, editable, color, id }): EventSourceInput => ({
             id,
-            events: events.flatMap(
-                (e) => toEventInput(e.id, e.event) || []
-            ),
+            events: events.flatMap((e) => toEventInput(e.id, e.event) || []),
             editable,
             ...getCalendarColors(color),
         })

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -50,6 +50,19 @@ function getCalendarColors(color: string | null | undefined): {
     };
 }
 
+export function translateSources(plugin : FullCalendarPlugin) {
+    return plugin.cache.getAllEvents().map(
+        ({ events, editable, color, id }): EventSourceInput => ({
+            id,
+            events: events.flatMap(
+                (e) => toEventInput(e.id, e.event) || []
+            ),
+            editable,
+            ...getCalendarColors(color),
+        })
+    );
+}
+
 export class CalendarView extends ItemView {
     plugin: FullCalendarPlugin;
     inSidebar: boolean;
@@ -80,19 +93,6 @@ export class CalendarView extends ItemView {
         return this.inSidebar ? "Full Calendar" : "Calendar";
     }
 
-    translateSources() {
-        return this.plugin.cache.getAllEvents().map(
-            ({ events, editable, color, id }): EventSourceInput => ({
-                id,
-                events: events.flatMap(
-                    (e) => toEventInput(e.id, e.event) || []
-                ),
-                editable,
-                ...getCalendarColors(color),
-            })
-        );
-    }
-
     async onOpen() {
         await this.plugin.loadSettings();
         if (!this.plugin.cache) {
@@ -116,7 +116,7 @@ export class CalendarView extends ItemView {
             return;
         }
 
-        const sources: EventSourceInput[] = this.translateSources();
+        const sources: EventSourceInput[] = translateSources(this.plugin);
 
         if (this.fullCalendarView) {
             this.fullCalendarView.destroy();
@@ -301,7 +301,7 @@ export class CalendarView extends ItemView {
         this.callback = this.plugin.cache.on("update", (payload) => {
             if (payload.type === "resync") {
                 this.fullCalendarView?.removeAllEventSources();
-                const sources = this.translateSources();
+                const sources = translateSources(this.plugin);
                 sources.forEach((source) =>
                     this.fullCalendarView?.addEventSource(source)
                 );


### PR DESCRIPTION
In trying to simply render the default calendar based on the global settings, I found it to be a bit difficult to do.

This PR simplifies the process by having the renderCalendar function default the events to all events from the event sources set in the global settings. I've also added this case as one of the basic examples in the documentation

