### PR TITLE
Skip adding remote duplicate events

### DIFF
--- a/src/core/EventCache.ts
+++ b/src/core/EventCache.ts
@@ -567,14 +567,16 @@ export default class EventCache {
                         location,
                         calendarId: calendar.id,
                     }));
-                    newEvents.forEach(({ event, id, location }) => {
-                        this.store.add({
-                            calendar,
-                            location,
-                            id,
-                            event,
+                    newEvents
+                        .filter(({ id }) => !this.store.has(id))
+                        .forEach(({ event, id, location }) => {
+                            this.store.add({
+                                calendar,
+                                location,
+                                id,
+                                event,
+                            });
                         });
-                    });
                     this.updateCalendar({
                         id: calendar.id,
                         editable: false,

--- a/src/core/EventStore.ts
+++ b/src/core/EventStore.ts
@@ -192,6 +192,10 @@ export default class EventStore {
         return result;
     }
 
+    has(id: string): boolean {
+        return this.store.has(id);
+    }
+
     /**
      * Add a new event to the store with given associations.
      * @param param0


### PR DESCRIPTION
A naive attempt to address #446.
When revalidating remote calendars, if an event with an ID already in the cache is found, just skip it.
This occurs after the events in the calendar are deleted, so naively I don't think this will run into concurrency issues, but I'd be grateful for somebody to think through it more carefully!