### PR TITLE
Visible event limit

### DIFF
--- a/src/ui/calendar.ts
+++ b/src/ui/calendar.ts
@@ -48,6 +48,8 @@ interface ExtraRenderProps {
     firstDay?: number;
     initialView?: { desktop: string; mobile: string };
     timeFormat24h?: boolean;
+    staticEventLimit?: boolean;
+    dayMaxEvents?: number;
     openContextMenuForEvent?: (
         event: EventApi,
         mouseEvent: MouseEvent
@@ -107,7 +109,8 @@ export function renderCalendar(
             (isNarrow ? "timeGrid3Days" : "timeGridWeek"),
         nowIndicator: true,
         scrollTimeReset: false,
-        dayMaxEvents: true,
+        dayMaxEvents: 
+            (settings?.staticEventLimit) ? (settings?.dayMaxEvents):(true),
 
         headerToolbar: !isNarrow
             ? {

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -26,6 +26,8 @@ export interface FullCalendarSettings {
         mobile: string;
     };
     timeFormat24h: boolean;
+    staticEventLimit: boolean;
+    dayMaxEvents: number;
 }
 
 export const DEFAULT_SETTINGS: FullCalendarSettings = {
@@ -37,6 +39,8 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
         mobile: "timeGrid3Days",
     },
     timeFormat24h: false,
+    staticEventLimit: false,
+    dayMaxEvents: 8,
 };
 
 const WEEKDAYS = [
@@ -230,6 +234,32 @@ export class FullCalendarSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 });
             });
+
+        containerEl.createEl("h2", { text: "Event limit" });
+        new Setting(containerEl)
+            .setName("Static event limit (Requires Reload)")
+            .setDesc("Change the number of events visible per day in the month view. Otherwise, it scales with the window size.")
+            .addToggle(toggle => {
+                toggle.setValue(this.plugin.settings.staticEventLimit);
+                toggle.onChange(async (val) =>{
+                    this.plugin.settings.staticEventLimit = val;
+                    await this.plugin.saveSettings();
+                }
+                )
+            })
+
+        new Setting(containerEl)
+            .setName("Maximum visible events (Requires Reload)")
+            .setDesc("If static event limit is true. The maximum number of events to display in one day.")
+            .addSlider(slider => {
+            slider.setValue(this.plugin.settings.dayMaxEvents)
+            slider.setLimits(3, 16, 1); // start, stop, step
+            slider.setDynamicTooltip();
+            slider.onChange(async (val) => {
+                this.plugin.settings.dayMaxEvents = val;
+                await this.plugin.saveSettings();
+            }); 
+        });
 
         containerEl.createEl("h2", { text: "Manage Calendars" });
         addCalendarButton(

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -235,22 +235,16 @@ export class FullCalendarSettingTab extends PluginSettingTab {
                 });
             });
 
-        containerEl.createEl("h2", { text: "Event limit" });
         new Setting(containerEl)
             .setName("Static event limit (Requires Reload)")
-            .setDesc("Change the number of events visible per day in the month view. Otherwise, it scales with the window size.")
+            .setDesc("The maximum number of events to display in one day. Otherwise, scales with the window size.")
             .addToggle(toggle => {
                 toggle.setValue(this.plugin.settings.staticEventLimit);
                 toggle.onChange(async (val) =>{
                     this.plugin.settings.staticEventLimit = val;
                     await this.plugin.saveSettings();
-                }
-                )
+                })
             })
-
-        new Setting(containerEl)
-            .setName("Maximum visible events (Requires Reload)")
-            .setDesc("If static event limit is true. The maximum number of events to display in one day.")
             .addSlider(slider => {
             slider.setValue(this.plugin.settings.dayMaxEvents)
             slider.setLimits(3, 16, 1); // start, stop, step

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -202,6 +202,8 @@ export class CalendarView extends ItemView {
             firstDay: this.plugin.settings.firstDay,
             initialView: this.plugin.settings.initialView,
             timeFormat24h: this.plugin.settings.timeFormat24h,
+            staticEventLimit: this.plugin.settings.staticEventLimit,
+            dayMaxEvents: this.plugin.settings.dayMaxEvents,
             openContextMenuForEvent: async (e, mouseEvent) => {
                 const menu = new Menu();
                 if (!this.plugin.cache) {


### PR DESCRIPTION
Adds a setting to change the maximum number of events able to be seen in one day. This affects the month view, as well as the all-day events in the day view

![Screenshot 2023-07-29 at 10 04 14](https://github.com/davish/obsidian-full-calendar/assets/60723204/e5a1a521-9d5c-4575-a2c0-3ac30e55dba6)

This either scales with the window size:

![Screenshot 2023-07-29 at 10 06 53](https://github.com/davish/obsidian-full-calendar/assets/60723204/698b8ee3-eb7d-4bbb-a9f2-e0d0f6d4b301)
![Screenshot 2023-07-29 at 10 07 27](https://github.com/davish/obsidian-full-calendar/assets/60723204/daa60418-3cc5-4fd8-b546-f17ba6852b2c)

Or with a static limit:
Limit of 3
![Screenshot 2023-07-29 at 10 06 18](https://github.com/davish/obsidian-full-calendar/assets/60723204/200ef600-e2d8-4792-9a31-49075342456a)
Limit of 16
![Screenshot 2023-07-29 at 10 08 05](https://github.com/davish/obsidian-full-calendar/assets/60723204/ce9400ba-1774-4941-a43d-4d3ae47e85cb)

IF there are more events than would usually would be allowed, it will try to shrink the height of other weeks, then add scroll bars to scroll up and down in the month view.