### PR TITLE
parse HH:mm:ss dates correctly

### DIFF
--- a/src/ui/interop.ts
+++ b/src/ui/interop.ts
@@ -13,6 +13,9 @@ const parseTime = (time: string): Duration | null => {
     if (parsed.invalidReason) {
         parsed = DateTime.fromFormat(time, "HH:mm");
     }
+    if (parsed.invalidReason) {
+        parsed = DateTime.fromFormat(time, "HH:mm:ss");
+    }
 
     if (parsed.invalidReason) {
         console.error(


### PR DESCRIPTION
Goodle Maps and other tools create `.ics` entries with second-precision (... don't ask _me_ why ...), so we need to be able to parse them correctly.

Simple & effective fix.