### PR TITLE
Add setting "Click day to create event" vs "Click to open day" (in month view)

### DIFF
--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -26,7 +26,7 @@ export interface FullCalendarSettings {
         mobile: string;
     };
     timeFormat24h: boolean;
-    clickToCreateEvent: boolean;
+    clickToCreateEventFromMonthView: boolean;
 }
 
 export const DEFAULT_SETTINGS: FullCalendarSettings = {
@@ -38,7 +38,7 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
         mobile: "timeGrid3Days",
     },
     timeFormat24h: false,
-    clickToCreateEvent: true,
+    clickToCreateEventFromMonthView: true,
 };
 
 const WEEKDAYS = [
@@ -237,9 +237,9 @@ export class FullCalendarSettingTab extends PluginSettingTab {
             .setName("Click on a day in month view to create event")
             .setDesc("Switch off to open day view on click instead.")
             .addToggle((toggle) => {
-                toggle.setValue(this.plugin.settings.clickToCreateEvent);
+                toggle.setValue(this.plugin.settings.clickToCreateEventFromMonthView);
                 toggle.onChange(async (val) => {
-                    this.plugin.settings.clickToCreateEvent = val;
+                    this.plugin.settings.clickToCreateEventFromMonthView = val;
                     await this.plugin.saveSettings();
                 });
             });

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -26,6 +26,7 @@ export interface FullCalendarSettings {
         mobile: string;
     };
     timeFormat24h: boolean;
+    clickToCreateEvent: boolean;
 }
 
 export const DEFAULT_SETTINGS: FullCalendarSettings = {
@@ -37,6 +38,7 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
         mobile: "timeGrid3Days",
     },
     timeFormat24h: false,
+    clickToCreateEvent: true,
 };
 
 const WEEKDAYS = [
@@ -227,6 +229,17 @@ export class FullCalendarSettingTab extends PluginSettingTab {
                 toggle.setValue(this.plugin.settings.timeFormat24h);
                 toggle.onChange(async (val) => {
                     this.plugin.settings.timeFormat24h = val;
+                    await this.plugin.saveSettings();
+                });
+            });
+
+        new Setting(containerEl)
+            .setName("Click on a day in month view to create event")
+            .setDesc("Switch off to open day view on click instead.")
+            .addToggle((toggle) => {
+                toggle.setValue(this.plugin.settings.clickToCreateEvent);
+                toggle.onChange(async (val) => {
+                    this.plugin.settings.clickToCreateEvent = val;
                     await this.plugin.saveSettings();
                 });
             });

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -160,7 +160,15 @@ export class CalendarView extends ItemView {
                     allDay
                 );
                 try {
-                    launchCreateModal(this.plugin, partialEvent);
+                    if (
+                        this.plugin.settings.clickToCreateEvent ||
+                        viewType !== "dayGridMonth"
+                    ) {
+                        launchCreateModal(this.plugin, partialEvent);
+                    } else {
+                        this.fullCalendarView?.changeView("timeGridDay");
+                        this.fullCalendarView?.gotoDate(start);
+                    }
                 } catch (e) {
                     if (e instanceof Error) {
                         console.error(e);

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -161,7 +161,7 @@ export class CalendarView extends ItemView {
                 );
                 try {
                     if (
-                        this.plugin.settings.clickToCreateEvent ||
+                        this.plugin.settings.clickToCreateEventFromMonthView ||
                         viewType !== "dayGridMonth"
                     ) {
                         launchCreateModal(this.plugin, partialEvent);


### PR DESCRIPTION
I like the month view, but I dislike the way I can select the time when trying to add an event (I need to type it in, or manually select minutes for 0 to 59). So might be nice to have an option to have clicking on a day from the month view does not open the "add event" modal directly, but first opens that specific day instead - so it's easier to select the time from the day view.

Setting added with this PR:
![Screenshot from 2023-09-03 09-35-54](https://github.com/davish/obsidian-full-calendar/assets/8506573/58909e2e-0b62-4c57-b991-e2f52bf35772)


This makes it easier to select the time when you come from month view (instead of having to select time in the edit modal directly):
![demo-time](https://github.com/davish/obsidian-full-calendar/assets/8506573/5d29df95-8d9d-4966-a512-4062fea2af2b)

