### PR TITLE
Always open in new tab setting

### DIFF
--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -1,20 +1,19 @@
 import { MarkdownView, TFile, Vault, Workspace } from "obsidian";
 import EventCache from "src/core/EventCache";
-import { FullCalendarSettings } from "./settings";
 
 /**
  * Open a file in the editor to a given event.
  * @param cache
  * @param param1 App
  * @param id event ID
- * @param settings settings from FullCalendar
+ * @param openInNewTab whether to open in new tab or not
  * @returns
  */
 export async function openFileForEvent(
     cache: EventCache,
     { workspace, vault }: { workspace: Workspace; vault: Vault },
     id: string,
-    settings?: FullCalendarSettings
+    openInNewTab: boolean
 ) {
     const details = cache.getInfoForEditableEvent(id);
     if (!details) {
@@ -31,7 +30,7 @@ export async function openFileForEvent(
     if (!leaf) {
         return;
     }
-    if (leaf.getViewState().pinned || settings?.alwaysOpenInNewTab) {
+    if (leaf.getViewState().pinned || openInNewTab) {
         leaf = workspace.getLeaf("tab");
     }
     await leaf.openFile(file);

--- a/src/ui/actions.ts
+++ b/src/ui/actions.ts
@@ -1,17 +1,20 @@
 import { MarkdownView, TFile, Vault, Workspace } from "obsidian";
 import EventCache from "src/core/EventCache";
+import { FullCalendarSettings } from "./settings";
 
 /**
  * Open a file in the editor to a given event.
  * @param cache
  * @param param1 App
  * @param id event ID
+ * @param settings settings from FullCalendar
  * @returns
  */
 export async function openFileForEvent(
     cache: EventCache,
     { workspace, vault }: { workspace: Workspace; vault: Vault },
-    id: string
+    id: string,
+    settings?: FullCalendarSettings
 ) {
     const details = cache.getInfoForEditableEvent(id);
     if (!details) {
@@ -28,7 +31,7 @@ export async function openFileForEvent(
     if (!leaf) {
         return;
     }
-    if (leaf.getViewState().pinned) {
+    if (leaf.getViewState().pinned || settings?.alwaysOpenInNewTab) {
         leaf = workspace.getLeaf("tab");
     }
     await leaf.openFile(file);

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -26,9 +26,9 @@ export interface FullCalendarSettings {
         mobile: string;
     };
     timeFormat24h: boolean;
-    clickToCreateEventFromMonthView: boolean;
-    alwaysOpenInNewTab: boolean;
-    ctrlClickToOpenFile: boolean;
+    clickToCreateEventFromMonthView?: boolean;
+    alwaysOpenInNewTab?: boolean;
+    ctrlClickToOpenFile?: boolean;
 }
 
 export const DEFAULT_SETTINGS: FullCalendarSettings = {
@@ -242,7 +242,7 @@ export class FullCalendarSettingTab extends PluginSettingTab {
             .setDesc("Switch off to open day view on click instead.")
             .addToggle((toggle) => {
                 toggle.setValue(
-                    this.plugin.settings.clickToCreateEventFromMonthView
+                    this.plugin.settings.clickToCreateEventFromMonthView ?? true
                 );
                 toggle.onChange(async (val) => {
                     this.plugin.settings.clickToCreateEventFromMonthView = val;
@@ -256,7 +256,9 @@ export class FullCalendarSettingTab extends PluginSettingTab {
                 "Switch off to only open events in a new tab when the current tab is pinned."
             )
             .addToggle((toggle) => {
-                toggle.setValue(this.plugin.settings.alwaysOpenInNewTab);
+                toggle.setValue(
+                    this.plugin.settings.alwaysOpenInNewTab ?? false
+                );
                 toggle.onChange(async (val) => {
                     this.plugin.settings.alwaysOpenInNewTab = val;
                     await this.plugin.saveSettings();
@@ -271,7 +273,9 @@ export class FullCalendarSettingTab extends PluginSettingTab {
                 "Switch off to have click open note (ctrl-click for edit modal)."
             )
             .addToggle((toggle) => {
-                toggle.setValue(this.plugin.settings.ctrlClickToOpenFile);
+                toggle.setValue(
+                    this.plugin.settings.ctrlClickToOpenFile ?? true
+                );
                 toggle.onChange(async (val) => {
                     this.plugin.settings.ctrlClickToOpenFile = val;
                     await this.plugin.saveSettings();

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -27,6 +27,7 @@ export interface FullCalendarSettings {
     };
     timeFormat24h: boolean;
     clickToCreateEventFromMonthView: boolean;
+    alwaysOpenInNewTab: boolean;
 }
 
 export const DEFAULT_SETTINGS: FullCalendarSettings = {
@@ -39,6 +40,7 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
     },
     timeFormat24h: false,
     clickToCreateEventFromMonthView: true,
+    alwaysOpenInNewTab: false,
 };
 
 const WEEKDAYS = [
@@ -242,6 +244,19 @@ export class FullCalendarSettingTab extends PluginSettingTab {
                 );
                 toggle.onChange(async (val) => {
                     this.plugin.settings.clickToCreateEventFromMonthView = val;
+                    await this.plugin.saveSettings();
+                });
+            });
+
+        new Setting(containerEl)
+            .setName("Always open events in a new tab")
+            .setDesc(
+                "Switch off to only open events in a new tab when the current tab is pinned."
+            )
+            .addToggle((toggle) => {
+                toggle.setValue(this.plugin.settings.alwaysOpenInNewTab);
+                toggle.onChange(async (val) => {
+                    this.plugin.settings.alwaysOpenInNewTab = val;
                     await this.plugin.saveSettings();
                 });
             });

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -28,6 +28,7 @@ export interface FullCalendarSettings {
     timeFormat24h: boolean;
     clickToCreateEventFromMonthView: boolean;
     alwaysOpenInNewTab: boolean;
+    ctrlClickToOpenFile: boolean;
 }
 
 export const DEFAULT_SETTINGS: FullCalendarSettings = {
@@ -41,6 +42,7 @@ export const DEFAULT_SETTINGS: FullCalendarSettings = {
     timeFormat24h: false,
     clickToCreateEventFromMonthView: true,
     alwaysOpenInNewTab: false,
+    ctrlClickToOpenFile: true,
 };
 
 const WEEKDAYS = [
@@ -257,6 +259,21 @@ export class FullCalendarSettingTab extends PluginSettingTab {
                 toggle.setValue(this.plugin.settings.alwaysOpenInNewTab);
                 toggle.onChange(async (val) => {
                     this.plugin.settings.alwaysOpenInNewTab = val;
+                    await this.plugin.saveSettings();
+                });
+            });
+
+        new Setting(containerEl)
+            .setName(
+                "Click opens the edit dialog (ctrl-click to open event note)"
+            )
+            .setDesc(
+                "Switch off to have click open note (ctrl-click for edit modal)."
+            )
+            .addToggle((toggle) => {
+                toggle.setValue(this.plugin.settings.ctrlClickToOpenFile);
+                toggle.onChange(async (val) => {
+                    this.plugin.settings.ctrlClickToOpenFile = val;
                     await this.plugin.saveSettings();
                 });
             });

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -133,7 +133,8 @@ export class CalendarView extends ItemView {
                         await openFileForEvent(
                             this.plugin.cache,
                             this.app,
-                            info.event.id
+                            info.event.id,
+                            this.plugin.settings
                         );
                     } else {
                         launchEditModal(this.plugin, info.event.id);

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -126,10 +126,13 @@ export class CalendarView extends ItemView {
             forceNarrow: this.inSidebar,
             eventClick: async (info) => {
                 try {
-                    if (
+                    const hasModifierKey =
                         info.jsEvent.getModifierState("Control") ||
-                        info.jsEvent.getModifierState("Meta")
-                    ) {
+                        info.jsEvent.getModifierState("Meta");
+                    const shouldOpenFile =
+                        hasModifierKey &&
+                        this.plugin.settings.ctrlClickToOpenFile;
+                    if (shouldOpenFile) {
                         await openFileForEvent(
                             this.plugin.cache,
                             this.app,


### PR DESCRIPTION
I prefer the calendar tab not to close when opening an event (but open a new tab instead). This way its easier to compare and switch notes of multiple events. So maybe we could add this setting to always have clicks to open in a new tab?

**Without setting** (current, many clicks needed)
![current](https://github.com/davish/obsidian-full-calendar/assets/8506573/68d18f20-3e43-46f6-8374-60a620015e81)

**With setting** (this PR, less clicks needed)
![new](https://github.com/davish/obsidian-full-calendar/assets/8506573/187713e6-7eb3-4f21-b01d-90f2c4fcd342)

**Invert Ctrl-setting for opening modal vs file**
Also (second commit in this PR), I tend to want to open the note more than I want to open the edit modal. So I added a setting for inverting the modifier key as well (ctrl for opening modal instead of ctrl for opening the file - notes are central for me):

![Screenshot from 2023-09-10 11-06-21](https://github.com/davish/obsidian-full-calendar/assets/8506573/bfc86994-62eb-43e0-9109-e23782ea7b20)


