### PR TITLE
Update zod-fast-check version in order to support fast-check@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "ts-jest": "^29.0.3",
         "tslib": "2.3.1",
         "typescript": "4.4.4",
-        "zod-fast-check": "^0.9.0"
+        "zod-fast-check": "^0.9.1"
     },
     "dependencies": {
         "@fullcalendar/core": "^5.10.1",


### PR DESCRIPTION
Since this project uses zod-fast-check version 0.9.0, it doesn't support fast-check version 3. This PR fixes this, updating the patch version to 0.9.1. [Source](https://github.com/DavidTimms/zod-fast-check/issues/10#issuecomment-1509302756).

Also solves #468.