### PR TITLE
Fix open of Full Calendar view if it already exists

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -72,9 +72,11 @@ export default class FullCalendarPlugin extends Plugin {
                 active: true,
             });
         } else {
-            await Promise.all(
-                leaves.map((l) => (l.view as CalendarView).onOpen())
-            );
+            const leaf = leaves[0];
+            await leaf.setViewState({
+                type: FULL_CALENDAR_VIEW_TYPE,
+                active: true,
+            });
         }
     }
     async onload() {


### PR DESCRIPTION
## Description

This fixes the "open" of the full calendar if the tab already exists. (in the videos, the tab is blank because it is the "No calendar available" screen).

#### Before

https://github.com/obsidian-community/obsidian-full-calendar/assets/24364012/c7119273-0211-4eb6-af55-5ca0f60ec2fa

#### After

https://github.com/obsidian-community/obsidian-full-calendar/assets/24364012/61840c08-6866-4b7c-a394-6bccf13d20b7

