### PR TITLE
[Docs] Fix incorrect links to calendars on getting-started page.

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,7 +2,7 @@
 
 ## Welcome page
 
-Open Full Calendar from the command palette or the ribbon icon for the first time and you'll be prompted to add a calendar. It's recommended that you add either a [Daily Note calendar](calendars/dailynote) or a [full note calendar](calendars/local) based in a directory in your Vault so that you can create and modify events. Remote calendars are currently read-only.
+Open Full Calendar from the command palette or the ribbon icon for the first time and you'll be prompted to add a calendar. It's recommended that you add either a [Daily Note calendar](../calendars/dailynote) or a [full note calendar](../calendars/local) based in a directory in your Vault so that you can create and modify events. Remote calendars are currently read-only.
 
 ![Welcome page](assets/welcome-settings.gif)
 


### PR DESCRIPTION
I noticed that clicking on "[Daily Note calendar](https://obsidian-community.github.io/obsidian-full-calendar/getting_started/calendars/dailynote)" or "[full note calendar](https://obsidian-community.github.io/obsidian-full-calendar/getting_started/calendars/local)" on the [Getting started](https://obsidian-community.github.io/obsidian-full-calendar/getting_started/) page resulted in navigating to `https://obsidian-community.github.io/obsidian-full-calendar/getting_started/calendars/dailynote` or `https://obsidian-community.github.io/obsidian-full-calendar/getting_started/calendars/local`, which had broken CSS. 

The expected page URLs are `https://obsidian-community.github.io/obsidian-full-calendar/calendars/dailynote` or `https://obsidian-community.github.io/obsidian-full-calendar/calendars/local`.