### PR TITLE
Fix all-day range event handling

### DIFF
--- a/src/ui/components/EditEvent.tsx
+++ b/src/ui/components/EditEvent.tsx
@@ -250,14 +250,31 @@ export const EditEvent = ({
                 </p>
                 <p>
                     {!isRecurring && (
-                        <input
-                            type="date"
-                            id="date"
-                            value={date}
-                            required={!isRecurring}
-                            // @ts-ignore
-                            onChange={makeChangeListener(setDate, (x) => x)}
-                        />
+                        <>
+                            <input
+                                type="date"
+                                id="date"
+                                value={date}
+                                required={!isRecurring}
+                                // @ts-ignore
+                                onChange={makeChangeListener(setDate, (x) => x)}
+                            />
+                            {allDay && (
+                                <>
+                                    -
+                                    <input
+                                        type="date"
+                                        id="endDate"
+                                        value={endDate || ""}
+                                        onChange={(e) =>
+                                            setEndDate(
+                                                e.currentTarget.value || null
+                                            )
+                                        }
+                                    />
+                                </>
+                            )}
+                        </>
                     )}
 
                     {allDay ? (

--- a/src/ui/interop.ts
+++ b/src/ui/interop.ts
@@ -59,6 +59,11 @@ const getTime = (date: Date): string =>
 
 const getDate = (date: Date): string => DateTime.fromJSDate(date).toISODate();
 
+const getInclusiveAllDayEndDate = (end: Date): string =>
+    DateTime.fromJSDate(end).minus({ days: 1 }).toISODate() || "";
+const getExclusiveAllDayEndDate = (endDate: string): string =>
+    DateTime.fromISO(endDate).plus({ days: 1 }).toISODate();
+
 const combineDateTimeStrings = (date: string, time: string): string | null => {
     const parsedDate = DateTime.fromISO(date);
     if (parsedDate.invalidReason) {
@@ -87,7 +92,8 @@ export function dateEndpointsToFrontmatter(
     allDay: boolean
 ): Partial<OFCEvent> {
     const date = getDate(start);
-    const endDate = getDate(end);
+    const endDate = allDay ? getInclusiveAllDayEndDate(end) : getDate(end);
+
     return {
         type: "single",
         date,
@@ -219,7 +225,9 @@ export function toEventInput(
             event = {
                 ...event,
                 start: frontmatter.date,
-                end: frontmatter.endDate || undefined,
+                end: frontmatter.endDate
+                    ? getExclusiveAllDayEndDate(frontmatter.endDate)
+                    : undefined,
                 extendedProps: {
                     isTask:
                         frontmatter.completed !== undefined &&
@@ -236,7 +244,12 @@ export function toEventInput(
 export function fromEventApi(event: EventApi): OFCEvent {
     const isRecurring: boolean = event.extendedProps.daysOfWeek !== undefined;
     const startDate = getDate(event.start as Date);
-    const endDate = getDate(event.end as Date);
+    const eventEnd = event.end as Date | null;
+    const endDate = eventEnd
+        ? event.allDay
+            ? getInclusiveAllDayEndDate(eventEnd)
+            : getDate(eventEnd)
+        : startDate;
     return {
         title: event.title,
         ...(event.allDay

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -146,14 +146,6 @@ export class CalendarView extends ItemView {
                 }
             },
             select: async (start, end, allDay, viewType) => {
-                if (viewType === "dayGridMonth") {
-                    // Month view will set the end day to the next day even on a single-day event.
-                    // This is problematic when moving an event created in the month view to the
-                    // time grid to give it a time.
-
-                    // The fix is just to subtract 1 from the end date before processing.
-                    end.setDate(end.getDate() - 1);
-                }
                 const partialEvent = dateEndpointsToFrontmatter(
                     start,
                     end,


### PR DESCRIPTION
## Summary

  This PR fixes all-day range event handling by treating the frontmatter
  `endDate` as an inclusive date while converting to FullCalendar's exclusive
  end date format.

  ## Changes

  - Convert all-day `endDate` from inclusive frontmatter date to
  FullCalendar's exclusive end date.
  - Convert all-day event API end dates back to inclusive `endDate` before
  saving.
  - Add an end date input for all-day events in the create/edit modal.
  - Remove the month-view-only end date adjustment now that the conversion is
  centralized.

  ## Verification

  - Ran `npm run compile`.
  - Ran `npm run build`.
  - Verified in a local vault that an all-day range event from 2026-08-01 to
  2026-08-05 is saved with `endDate: 2026-08-05` and displayed across the
  expected date range.
  